### PR TITLE
GitHub restriction recovery: wire the read side back up

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -474,6 +474,31 @@ Validates `totalCount ≤ 500,000`. Performs an upsert on `StargazerCache`.
 
 ---
 
+### `GET /api/reconstruct/[owner]/[repo]`
+
+Rebuilds a map from `star_event ⨝ github_user` when no `stargazer_cache` blob exists. First fallback of the degraded chain in `src/hooks/use-repo-cache-loader.ts`.
+
+**Responses**:
+- `200`: `{ points: StargazerPoint[], unmapped: { login }[], totalCount }`, coordinates rounded to 2 decimals
+- `404`: no `star_event` row for this repo
+- `503`: `{ error: "timeout" }`, Neon `statement_timeout` (`P2010`) or pool exhaustion (`P2024`)
+
+Capped at the 10,000 most recent stars (`RESULT_CAP`) with `maxDuration = 30`. The client never persists this response to localStorage or `badge_cache`.
+
+---
+
+### `GET /api/engaged/[owner]/[repo]`
+
+Serves the engaged-audience map (forkers, issue and PR authors, mentionables, watchers) written by `scripts/ops/index-engaged.ts`. Second fallback of the degraded chain, used when reconstruction also fails.
+
+**Responses**:
+- `200`: `{ points, unmapped, knownCount, starCount, channels: string[], scannedAt }`
+- `404`: no `engaged_cache` row for this repo
+
+Points carry no `location`, `company` or `starredAt`, so the stats panel hides its location-derived aggregates for this source.
+
+---
+
 ### `POST /api/user-details`
 
 Fetches enriched profile data for a list of stargazers (bio, followers, company). Used to populate detail cards when a user clicks a map point.

--- a/docs/superpowers/plans/2026-07-31-github-restriction-recovery.md
+++ b/docs/superpowers/plans/2026-07-31-github-restriction-recovery.md
@@ -21,7 +21,7 @@
 
 ---
 
-## Track A: `/api/engaged/[owner]/[repo]` read route
+## Task 1: `/api/engaged/[owner]/[repo]` read route (Track A)
 
 Makes the already-shipped `EngagedCache` table (`570a367`, currently write-only) readable. Mirrors `src/app/api/stargazer-cache/[owner]/[repo]/route.ts` almost line for line.
 
@@ -212,7 +212,7 @@ git commit -m "feat(api): add engaged-audience read route"
 
 ---
 
-## Track B: `/api/reconstruct/[owner]/[repo]` read route
+## Task 2: `/api/reconstruct/[owner]/[repo]` read route (Track B)
 
 Ships ROADMAP.md Phase 1, currently unbuilt despite the doc calling it "the near-term win... does not wait on Phase 3" (`docs/ROADMAP.md:80`). Joins `star_event` and `github_user` on `login`, filtered by `owner`/`repo`. Zero new GitHub API calls, works purely off the 33M rows already in `star_event`.
 
@@ -400,7 +400,7 @@ git commit -m "feat(api): add star_event reconstruction read route"
 
 ---
 
-## Track C: wire the fallback chain into the repo page
+## Task 3: wire the fallback chain into the repo page (Track C)
 
 `src/hooks/use-repo-cache-loader.ts` currently gives up silently on a `stargazer_cache` miss (line 120: `if (!r.ok) { ...; return; }`, which is exactly the empty-map state the July 24 UI work (`bb179cd`) added a notice for). Insert `/api/reconstruct` then `/api/engaged` as fallbacks before that give-up, and track which source served the data so the UI never claims a degraded map is a full scan.
 
@@ -645,7 +645,7 @@ git commit -m "feat(map): fall back to reconstruct/engaged data, label honestly"
 
 ---
 
-## Track D: Phase 2 coverage metric
+## Task 4: Phase 2 coverage metric (Track D)
 
 `docs/ROADMAP.md:84` specs `0.3 * N / M` (N = distinct logins in `star_event` for the repo, M = live `stargazerCount`) instead of raw `N/M`, which overstates coverage ~3x since only 30% of `github_user` rows are geolocated. Neither the `BadgeCache.knownCount`/`coverageComputedAt` columns nor the computation exist yet.
 
@@ -739,7 +739,7 @@ git commit -m "feat(db): add coverage metric fields and weighted formula"
 
 ---
 
-## Track E: legal ToS read for Phase 3 (not code)
+## Task 90: legal ToS read for Phase 3, not code, not dispatched (Track E)
 
 `docs/ROADMAP.md:100` ranks this risk #1, BLOCKER: *"Pooling GraphQL quota across 3 accounts and 4 tokens is itself ToS-fragile... A legal/ToS read is required before Phase 3, this is not something to engineer around."* Checked during this planning pass: `claudedocs/audit-rgpd-legal-2026-04-17.md` (the only existing legal doc) has zero mentions of `starredRepositories`, pooling, or circumvention. It covers the stargazer-list scraping question only, not the crawler's multi-account quota-pooling question. No document answers this. Phase 0's own gate is already clear (`before-after-and-poc-plan.md`: 94.4% median leave-one-out recovery, threshold was 20%), so the crawler is blocked on this alone.
 
@@ -747,7 +747,7 @@ git commit -m "feat(db): add coverage metric fields and weighted formula"
 
 ---
 
-## Track F: resync `/roadmap` page copy (after Tracks A-C ship)
+## Task 5: resync `/roadmap` page copy (Track F, after Tasks 1-3 ship)
 
 Once Track C is live, option A's public claim ("Already shipping") stops being misleading, since the engaged-audience map becomes something a visitor can actually see. Do this last, not first: resyncing copy before the feature is visible just moves the same overclaim from README to `/roadmap`.
 
@@ -769,7 +769,7 @@ git commit -m "docs(roadmap): update option A copy now the map is visible"
 
 ---
 
-## Self-Review
+## Task 91: Self-Review notes, not a task
 
 **Spec coverage:** Track A covers making `EngagedCache` readable (the immediate gap found this session). Track B covers ROADMAP.md Phase 1 (explicitly "does not wait on Phase 3"). Track C covers the actual user-visible wiring both A and B need to matter at all, plus the honesty requirement (never label degraded data as a full scan). Track D covers ROADMAP.md Phase 2. Track E surfaces the Phase 3 BLOCKER as an explicit non-engineering action instead of leaving it silent in a doc. Track F closes the roadmap-page/reality gap flagged earlier this session, sequenced after the feature actually ships.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,8 @@ model BadgeCache {
   organicScore       Int?
   organicTier        String?
   organicComputedAt  DateTime?
+  knownCount         Int?
+  coverageComputedAt DateTime?
   openIssuesCount    Int?
   openPRsCount       Int?
   latestReleaseTag   String?

--- a/src/app/[owner]/[repo]/page.client.tsx
+++ b/src/app/[owner]/[repo]/page.client.tsx
@@ -16,6 +16,7 @@ const RateLimitedModal = dynamic(() => import("@/components/map/rate-limited-mod
 const RepoNotFoundModal = dynamic(() => import("@/components/map/not-found-modal").then((m) => ({ default: m.RepoNotFoundModal })), { ssr: false });
 import { RateLimitOverlay } from "@/components/map/rate-limit-overlay";
 import { PreScanOverlay } from "@/components/map/pre-scan-overlay";
+import { DataSourceBadge } from "@/components/map/data-source-badge";
 import { StargazerMapDynamic } from "@/components/map/stargazer-map-dynamic";
 import { MapFloatingNav } from "@/components/map/map-floating-nav";
 import { CLUSTER_RADIUS } from "@/components/map/constants";
@@ -244,7 +245,7 @@ export default function MapPageClient({ owner, repo, initialRepoInfo, initialSta
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner, repo]); // initialRepoInfo is stable after mount — intentionally excluded
 
-  const { cacheCheckDone, lastDbScan } = useRepoCacheLoader({
+  const { cacheCheckDone, lastDbScan, dataSource } = useRepoCacheLoader({
     owner, repo, repoInfo,
     currentStars: initialRepoInfo?.stars,
     dispatch, setTotal, setCachedAt, setLatestStarredAt, setStatus, setServerStats,
@@ -565,6 +566,12 @@ export default function MapPageClient({ owner, repo, initialRepoInfo, initialSta
         findStatus={findStatus}
         organic={organicData ?? serverStats?.organic}
       />
+
+      {(dataSource === "reconstructed" || dataSource === "engaged") && (
+        <div className="absolute top-16 left-4 z-10">
+          <DataSourceBadge source={dataSource} />
+        </div>
+      )}
 
       {/* Shared-view banner — shown when URL encoded filters were detected on load */}
       {sharedView && (

--- a/src/app/[owner]/[repo]/page.client.tsx
+++ b/src/app/[owner]/[repo]/page.client.tsx
@@ -479,7 +479,13 @@ export default function MapPageClient({ owner, repo, initialRepoInfo, initialSta
           </div>
         )}
 
+      {/* Bottom-centred stack: TopPanel spans calc(100vw-2rem) below ~900px, so any
+          top-anchored badge lands on top of it. This column is already clear of the Dock
+          (bottom-left) and the compare pill (bottom-right). */}
       <div className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10 pointer-events-none flex flex-col items-center gap-1.5">
+        {(dataSource === "reconstructed" || dataSource === "engaged") && (
+          <DataSourceBadge source={dataSource} />
+        )}
         <div className="flex items-center gap-2">
           <a
             href="https://florian.bruniaux.com"
@@ -566,12 +572,6 @@ export default function MapPageClient({ owner, repo, initialRepoInfo, initialSta
         findStatus={findStatus}
         organic={organicData ?? serverStats?.organic}
       />
-
-      {(dataSource === "reconstructed" || dataSource === "engaged") && (
-        <div className="absolute top-16 left-4 z-10">
-          <DataSourceBadge source={dataSource} />
-        </div>
-      )}
 
       {/* Shared-view banner — shown when URL encoded filters were detected on load */}
       {sharedView && (
@@ -806,6 +806,7 @@ export default function MapPageClient({ owner, repo, initialRepoInfo, initialSta
           starsThisMonth={starsThisMonth}
           contributorsCount={repoInfo?.contributorsCount ?? null}
           repoStars={repoInfo?.stars ?? total}
+          hideLocationAggregates={dataSource === "engaged"}
         />
       )}
     </main>

--- a/src/app/api/engaged/[owner]/[repo]/__tests__/route.test.ts
+++ b/src/app/api/engaged/[owner]/[repo]/__tests__/route.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockFind = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    engagedCache: { findUnique: (...args: unknown[]) => mockFind(...args) },
+  },
+}));
+
+const POINTS = [{ login: "a", lat: 1, lng: 2 }];
+const UNMAPPED = [{ login: "b" }];
+
+vi.mock("@/lib/compression", () => ({
+  decompressGzBase64: (v: unknown) => {
+    if (v === "gz_points") return POINTS;
+    if (v === "gz_unmapped") return UNMAPPED;
+    return [];
+  },
+}));
+
+import { GET } from "@/app/api/engaged/[owner]/[repo]/route";
+
+const makeReq = (
+  owner: string,
+  repo: string,
+): [NextRequest, { params: Promise<{ owner: string; repo: string }> }] => [
+  new NextRequest(`http://localhost/api/engaged/${owner}/${repo}`),
+  { params: Promise.resolve({ owner, repo }) },
+];
+
+const SCANNED_AT = new Date("2026-07-26T00:00:00Z");
+const ROW = {
+  scannedAt: SCANNED_AT,
+  pointsGz: "gz_points",
+  unmappedGz: "gz_unmapped",
+  knownCount: 2,
+  starCount: 100,
+  channels: "fork,issue,pr,mention,watch",
+};
+
+describe("GET /api/engaged/[owner]/[repo]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFind.mockResolvedValue(null);
+  });
+
+  it("returns 400 for invalid owner", async () => {
+    const [req, ctx] = makeReq("bad owner!", "repo");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when no engaged_cache row exists", async () => {
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with points, unmapped, knownCount, starCount, channels", async () => {
+    mockFind.mockResolvedValue(ROW);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.knownCount).toBe(2);
+    expect(json.starCount).toBe(100);
+    expect(json.channels).toEqual(["fork", "issue", "pr", "mention", "watch"]);
+    expect(Array.isArray(json.points)).toBe(true);
+    expect(Array.isArray(json.unmapped)).toBe(true);
+  });
+
+  it("adds avatarUrl derived from login when missing from stored point", async () => {
+    mockFind.mockResolvedValue(ROW);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.points[0].avatarUrl).toBe("https://github.com/a.png");
+  });
+
+  it("returns 500 when DB throws", async () => {
+    mockFind.mockRejectedValue(new Error("DB error"));
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/engaged/[owner]/[repo]/route.ts
+++ b/src/app/api/engaged/[owner]/[repo]/route.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { validateOwnerRepo } from "@/lib/api-validation";
+import { jsonError, logError } from "@/lib/api-helpers";
+import { decompressGzBase64 } from "@/lib/compression";
+
+export const GET = async (
+  _req: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+) => {
+  const { owner, repo } = await params;
+  const key = validateOwnerRepo(owner, repo);
+  if (!key) return jsonError("invalid_params", 400);
+
+  try {
+    const cached = await prisma.engagedCache.findUnique({
+      where: { owner_repo: key },
+      select: {
+        pointsGz: true,
+        unmappedGz: true,
+        knownCount: true,
+        starCount: true,
+        channels: true,
+        scannedAt: true,
+      },
+    });
+    if (!cached) return jsonError("not_found", 404);
+
+    const points = decompressGzBase64<Record<string, unknown>>(cached.pointsGz);
+    const unmapped = decompressGzBase64(cached.unmappedGz);
+
+    const pointsWithAvatar = points.map((p) => ({
+      ...p,
+      avatarUrl: p.avatarUrl ?? `https://github.com/${p.login}.png`,
+      ...(typeof p.lat === "number" && typeof p.lng === "number"
+        ? { lat: Math.round(p.lat * 100) / 100, lng: Math.round(p.lng * 100) / 100 }
+        : {}),
+    }));
+
+    return NextResponse.json(
+      {
+        points: pointsWithAvatar,
+        unmapped,
+        knownCount: cached.knownCount,
+        starCount: cached.starCount,
+        channels: cached.channels.split(","),
+        scannedAt: cached.scannedAt.toISOString(),
+      },
+      { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600" } },
+    );
+  } catch (err) {
+    logError("engaged GET", err);
+    return jsonError("internal", 500);
+  }
+};

--- a/src/app/api/reconstruct/[owner]/[repo]/__tests__/route.test.ts
+++ b/src/app/api/reconstruct/[owner]/[repo]/__tests__/route.test.ts
@@ -21,8 +21,8 @@ const makeReq = (
 ];
 
 const ROWS = [
-  { login: "a", name: null, company: null, location: "Paris", followers: 10, lat: 48.8566, lng: 2.3522, starredAt: new Date("2024-01-01") },
-  { login: "b", name: null, company: null, location: null, followers: 3, lat: null, lng: null, starredAt: new Date("2024-01-02") },
+  { login: "a", name: null, company: null, location: "Paris", followers: 10, lat: 48.8566, lng: 2.3522, linkedinUrl: "https://linkedin.com/in/a", starredAt: new Date("2024-01-01") },
+  { login: "b", name: null, company: null, location: null, followers: 3, lat: null, lng: null, linkedinUrl: null, starredAt: new Date("2024-01-02") },
 ];
 
 describe("GET /api/reconstruct/[owner]/[repo]", () => {
@@ -67,6 +67,37 @@ describe("GET /api/reconstruct/[owner]/[repo]", () => {
     const [req, ctx] = makeReq("octocat", "hello");
     const json = await (await GET(req, ctx)).json();
     expect(json.points[0].avatarUrl).toBe("https://github.com/a.png");
+  });
+
+  it("passes linkedinUrl through instead of hardcoding null", async () => {
+    mockQueryRaw.mockResolvedValue(ROWS);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.points[0].linkedinUrl).toBe("https://linkedin.com/in/a");
+  });
+
+  it("caps the query with a LIMIT so the star_event join stays bounded", async () => {
+    mockQueryRaw.mockResolvedValue(ROWS);
+    const [req, ctx] = makeReq("octocat", "hello");
+    await GET(req, ctx);
+    const [strings, ...values] = mockQueryRaw.mock.calls[0] as [string[], ...unknown[]];
+    expect(strings.join("?")).toContain("LIMIT");
+    expect(values).toContain(10_000);
+  });
+
+  it("returns 503, not 500, when Neon times out the query (P2010)", async () => {
+    mockQueryRaw.mockRejectedValue(Object.assign(new Error("statement timeout"), { code: "P2010" }));
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe("timeout");
+  });
+
+  it("returns 503 when the connection pool is exhausted (P2024)", async () => {
+    mockQueryRaw.mockRejectedValue(Object.assign(new Error("pool timeout"), { code: "P2024" }));
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(503);
   });
 
   it("returns 500 when the query throws", async () => {

--- a/src/app/api/reconstruct/[owner]/[repo]/__tests__/route.test.ts
+++ b/src/app/api/reconstruct/[owner]/[repo]/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockQueryRaw = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  prisma: { $queryRaw: (...args: unknown[]) => mockQueryRaw(...args) },
+}));
+
+import { GET } from "@/app/api/reconstruct/[owner]/[repo]/route";
+
+const makeReq = (
+  owner: string,
+  repo: string,
+): [NextRequest, { params: Promise<{ owner: string; repo: string }> }] => [
+  new NextRequest(`http://localhost/api/reconstruct/${owner}/${repo}`),
+  { params: Promise.resolve({ owner, repo }) },
+];
+
+const ROWS = [
+  { login: "a", name: null, company: null, location: "Paris", followers: 10, lat: 48.8566, lng: 2.3522, starredAt: new Date("2024-01-01") },
+  { login: "b", name: null, company: null, location: null, followers: 3, lat: null, lng: null, starredAt: new Date("2024-01-02") },
+];
+
+describe("GET /api/reconstruct/[owner]/[repo]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockQueryRaw.mockResolvedValue([]);
+  });
+
+  it("returns 400 for invalid owner", async () => {
+    const [req, ctx] = makeReq("bad owner!", "repo");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when star_event has no rows for this repo", async () => {
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("splits rows into mapped points and unmapped by lat/lng presence", async () => {
+    mockQueryRaw.mockResolvedValue(ROWS);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.points).toHaveLength(1);
+    expect(json.points[0].login).toBe("a");
+    expect(json.unmapped).toHaveLength(1);
+    expect(json.unmapped[0].login).toBe("b");
+    expect(json.totalCount).toBe(2);
+  });
+
+  it("rounds lat/lng to 2 decimals", async () => {
+    mockQueryRaw.mockResolvedValue(ROWS);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.points[0].lat).toBe(48.86);
+    expect(json.points[0].lng).toBe(2.35);
+  });
+
+  it("derives avatarUrl from login", async () => {
+    mockQueryRaw.mockResolvedValue(ROWS);
+    const [req, ctx] = makeReq("octocat", "hello");
+    const json = await (await GET(req, ctx)).json();
+    expect(json.points[0].avatarUrl).toBe("https://github.com/a.png");
+  });
+
+  it("returns 500 when the query throws", async () => {
+    mockQueryRaw.mockRejectedValue(new Error("DB error"));
+    const [req, ctx] = makeReq("octocat", "hello");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/reconstruct/[owner]/[repo]/route.ts
+++ b/src/app/api/reconstruct/[owner]/[repo]/route.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { validateOwnerRepo } from "@/lib/api-validation";
+import { jsonError, logError } from "@/lib/api-helpers";
+
+type Row = {
+  login: string;
+  name: string | null;
+  company: string | null;
+  location: string | null;
+  followers: number;
+  lat: number | null;
+  lng: number | null;
+  starredAt: Date;
+};
+
+export const GET = async (
+  _req: NextRequest,
+  { params }: { params: Promise<{ owner: string; repo: string }> },
+) => {
+  const { owner, repo } = await params;
+  const key = validateOwnerRepo(owner, repo);
+  if (!key) return jsonError("invalid_params", 400);
+
+  try {
+    const rows = await prisma.$queryRaw<Row[]>`
+      SELECT u.login, u.name, u.company, u.location, u.followers, u.lat, u.lng, se."starredAt"
+      FROM star_event se
+      JOIN github_user u ON u.login = se.login
+      WHERE se.owner = ${key.owner} AND se.repo = ${key.repo}
+      ORDER BY se."starredAt" DESC
+    `;
+    if (rows.length === 0) return jsonError("not_found", 404);
+
+    const points = rows
+      .filter((r) => r.lat !== null && r.lng !== null)
+      .map((r) => ({
+        login: r.login,
+        name: r.name,
+        bio: null,
+        company: r.company,
+        location: r.location,
+        followers: r.followers,
+        avatarUrl: `https://github.com/${r.login}.png`,
+        lat: Math.round((r.lat as number) * 100) / 100,
+        lng: Math.round((r.lng as number) * 100) / 100,
+        starredAt: r.starredAt.toISOString(),
+        linkedinUrl: null,
+      }));
+    const unmapped = rows
+      .filter((r) => r.lat === null || r.lng === null)
+      .map((r) => ({ login: r.login }));
+
+    return NextResponse.json(
+      { points, unmapped, totalCount: rows.length },
+      { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600" } },
+    );
+  } catch (err) {
+    logError("reconstruct GET", err);
+    return jsonError("internal", 500);
+  }
+};

--- a/src/app/api/reconstruct/[owner]/[repo]/route.ts
+++ b/src/app/api/reconstruct/[owner]/[repo]/route.ts
@@ -7,6 +7,12 @@ import { prisma } from "@/lib/db";
 import { validateOwnerRepo } from "@/lib/api-validation";
 import { jsonError, logError } from "@/lib/api-helpers";
 
+export const maxDuration = 30;
+
+// star_event ⨝ github_user on 11M rows hits Neon's statement_timeout unbounded — see the
+// same note in /api/geo. The map clusters, so the newest 10k stars carry the shape fine.
+const RESULT_CAP = 10_000;
+
 type Row = {
   login: string;
   name: string | null;
@@ -15,6 +21,7 @@ type Row = {
   followers: number;
   lat: number | null;
   lng: number | null;
+  linkedinUrl: string | null;
   starredAt: Date;
 };
 
@@ -27,13 +34,34 @@ export const GET = async (
   if (!key) return jsonError("invalid_params", 400);
 
   try {
-    const rows = await prisma.$queryRaw<Row[]>`
-      SELECT u.login, u.name, u.company, u.location, u.followers, u.lat, u.lng, se."starredAt"
-      FROM star_event se
-      JOIN github_user u ON u.login = se.login
-      WHERE se.owner = ${key.owner} AND se.repo = ${key.repo}
-      ORDER BY se."starredAt" DESC
-    `;
+    let rows: Row[];
+    try {
+      rows = await prisma.$queryRaw<Row[]>`
+        SELECT u.login, u.name, u.company, u.location, u.followers, u.lat, u.lng,
+               u."linkedinUrl", se."starredAt"
+        FROM star_event se
+        JOIN github_user u ON u.login = se.login
+        WHERE se.owner = ${key.owner} AND se.repo = ${key.repo}
+        ORDER BY se."starredAt" DESC
+        LIMIT ${RESULT_CAP}
+      `;
+    } catch (err) {
+      // P2010 = raw query failed (statement_timeout from Neon)
+      // P2024 = connection pool exhausted
+      const isOverload =
+        err != null &&
+        typeof err === "object" &&
+        "code" in err &&
+        (err.code === "P2010" || err.code === "P2024");
+      if (!isOverload) throw err;
+      // Repo identity goes in the tag, not as a second arg: logError() calls sanitizeError(err),
+      // which stringifies a plain object to "[object Object]".
+      logError(`reconstruct timeout [${key.owner}/${key.repo}]`, err);
+      // 503 rather than the influential route's 200 + timedOut flag: the caller
+      // (use-repo-cache-loader) falls through to /api/engaged on a non-ok response, and a
+      // 200 with zero points would instead render an empty map labeled "reconstructed".
+      return jsonError("timeout", 503);
+    }
     if (rows.length === 0) return jsonError("not_found", 404);
 
     const points = rows
@@ -49,7 +77,7 @@ export const GET = async (
         lat: Math.round((r.lat as number) * 100) / 100,
         lng: Math.round((r.lng as number) * 100) / 100,
         starredAt: r.starredAt.toISOString(),
-        linkedinUrl: null,
+        linkedinUrl: r.linkedinUrl,
       }));
     const unmapped = rows
       .filter((r) => r.lat === null || r.lng === null)

--- a/src/components/map/data-source-badge.test.tsx
+++ b/src/components/map/data-source-badge.test.tsx
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DataSourceBadge } from "@/components/map/data-source-badge";
+
+describe("DataSourceBadge", () => {
+  it("labels reconstructed data honestly, not as a full scan", () => {
+    render(<DataSourceBadge source="reconstructed" />);
+    expect(screen.getByText(/reconstructed/i)).toBeInTheDocument();
+  });
+
+  it("labels engaged-community data with its own copy", () => {
+    render(<DataSourceBadge source="engaged" />);
+    expect(screen.getByText(/engaged community/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/map/data-source-badge.tsx
+++ b/src/components/map/data-source-badge.tsx
@@ -9,7 +9,7 @@ const COPY: Record<Props["source"], string> = {
 };
 
 export const DataSourceBadge = ({ source }: Props) => (
-  <div className="bg-surface-alt border border-border-subtle text-muted-subtle text-xs px-2 py-1 rounded-md">
+  <div className="bg-surface-alt/90 backdrop-blur-sm border border-border-subtle text-muted-subtle text-2xs text-center px-2 py-1 rounded-md max-w-xs">
     {COPY[source]}
   </div>
 );

--- a/src/components/map/data-source-badge.tsx
+++ b/src/components/map/data-source-badge.tsx
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+type Props = { source: "reconstructed" | "engaged" };
+
+const COPY: Record<Props["source"], string> = {
+  reconstructed: "Reconstructed from our own database, not a fresh scan",
+  engaged: "Showing the engaged community (forkers, contributors), not stargazers",
+};
+
+export const DataSourceBadge = ({ source }: Props) => (
+  <div className="bg-surface-alt border border-border-subtle text-muted-subtle text-xs px-2 py-1 rounded-md">
+    {COPY[source]}
+  </div>
+);

--- a/src/components/map/stats-modal.test.tsx
+++ b/src/components/map/stats-modal.test.tsx
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatsModal } from "@/components/map/stats-modal";
+import type { RepoStats } from "@/app/api/stats/[owner]/[repo]/route";
+
+// Engaged-audience points carry no location and no company, so every location-derived
+// aggregate computes to 0. A visible "0 countries" over a populated map reads as a bug.
+const EMPTY_LOCATION_STATS: RepoStats = {
+  totalStars: 400,
+  mappedCount: 120,
+  mappingRate: 30,
+  avgFollowers: 42,
+  countryCount: 0,
+  topCountries: [],
+  topCities: [],
+  topCompanies: [],
+  topUsers: [
+    { login: "octocat", name: "Octo", followers: 900, publicRepos: 12, location: null, avatarUrl: "https://github.com/octocat.png", company: null },
+  ],
+  powerStargazers: [],
+  botCount: 0,
+  enrichedUserCount: 0,
+  isCapped: false,
+  organic: null,
+};
+
+const noop = () => {};
+
+describe("StatsModal", () => {
+  it("shows country/city/company views by default", () => {
+    render(
+      <StatsModal open onClose={noop} owner="o" repo="r" displayStats={EMPTY_LOCATION_STATS} starsThisMonth={0} />,
+    );
+    expect(screen.getByRole("tab", { name: "Countries" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Cities" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Companies" })).toBeInTheDocument();
+    expect(screen.getByText("countries")).toBeInTheDocument();
+  });
+
+  it("hides location-derived tabs and tiles when the source has no location data", () => {
+    render(
+      <StatsModal open onClose={noop} owner="o" repo="r" displayStats={EMPTY_LOCATION_STATS} starsThisMonth={0} hideLocationAggregates />,
+    );
+    expect(screen.queryByRole("tab", { name: "Countries" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Cities" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Companies" })).toBeNull();
+    expect(screen.queryByText("countries")).toBeNull();
+    expect(screen.queryByText("cities")).toBeNull();
+    // Follower-based views stay: they are the ones engaged data can actually fill.
+    expect(screen.getByRole("tab", { name: "Top Stars" })).toBeInTheDocument();
+    expect(screen.getByText("avg flw")).toBeInTheDocument();
+  });
+});

--- a/src/components/map/stats-modal.tsx
+++ b/src/components/map/stats-modal.tsx
@@ -19,9 +19,17 @@ type StatsModalProps = {
   starsThisMonth: number;
   contributorsCount?: number | null;
   repoStars?: number;
+  /**
+   * Engaged-community points carry no location or company, so every location-derived
+   * aggregate would render a hard 0. Hiding reads as a limitation; a 0 reads as a bug.
+   */
+  hideLocationAggregates?: boolean;
 };
 
-export const StatsModal = ({ open, onClose, owner, repo, displayStats, starsThisMonth, contributorsCount, repoStars }: StatsModalProps) => {
+const ALL_TABS = ["top", "countries", "cities", "companies", "power", "rising"] as const;
+const TABS_WITHOUT_LOCATION = ["top", "power", "rising"] as const;
+
+export const StatsModal = ({ open, onClose, owner, repo, displayStats, starsThisMonth, contributorsCount, repoStars, hideLocationAggregates = false }: StatsModalProps) => {
   const [statsTab, setStatsTab] = useState<"countries" | "cities" | "top" | "companies" | "power" | "rising">("top");
   const [geoVelocity, setGeoVelocity] = useState<GeoVelocityItem[] | null>(null);
   const [geoVelocityLoading, setGeoVelocityLoading] = useState(false);
@@ -55,18 +63,22 @@ export const StatsModal = ({ open, onClose, owner, repo, displayStats, starsThis
                 `# ${owner}/${repo} on StarMapper`,
                 ``,
                 `- **Total stargazers**: ${(repoStars ?? displayStats.totalStars).toLocaleString()} (${displayStats.mappingRate}% mapped)`,
-                `- **Countries**: ${displayStats.countryCount}`,
-                `- **Cities**: ${displayStats.topCities.length}`,
+                ...(hideLocationAggregates ? [] : [
+                  `- **Countries**: ${displayStats.countryCount}`,
+                  `- **Cities**: ${displayStats.topCities.length}`,
+                ]),
                 `- **Avg followers**: ${displayStats.avgFollowers.toLocaleString()}`,
                 ``,
-                `## Top Countries`,
-                ...displayStats.topCountries.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`),
-                ``,
-                `## Top Cities`,
-                ...displayStats.topCities.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`),
-                `## Top Companies`,
-                ...(displayStats.topCompanies.length ? displayStats.topCompanies.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`) : ["No company data"]),
-                ``,
+                ...(hideLocationAggregates ? [] : [
+                  `## Top Countries`,
+                  ...displayStats.topCountries.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`),
+                  ``,
+                  `## Top Cities`,
+                  ...displayStats.topCities.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`),
+                  `## Top Companies`,
+                  ...(displayStats.topCompanies.length ? displayStats.topCompanies.slice(0, 10).map(([c, n], i) => `${i + 1}. ${c}: ${n}`) : ["No company data"]),
+                  ``,
+                ]),
                 `## Top Stargazers`,
                 ...displayStats.topUsers.slice(0, 10).map((u, i) => `${i + 1}. [@${u.login}](https://github.com/${u.login}) (${u.followers.toLocaleString()} followers)`),
                 ``,
@@ -106,14 +118,18 @@ export const StatsModal = ({ open, onClose, owner, repo, displayStats, starsThis
               <div className="text-xl font-bold text-accent-green">{displayStats.mappingRate}%</div>
               <div className="text-2xs text-muted uppercase tracking-wide mt-0.5">mapped</div>
             </div>
-            <div className="bg-background rounded-lg px-2 py-2 text-center">
-              <div className="text-xl font-bold text-foreground">{displayStats.countryCount}</div>
-              <div className="text-2xs text-muted uppercase tracking-wide mt-0.5">countries</div>
-            </div>
-            <div className="bg-background rounded-lg px-2 py-2 text-center">
-              <div className="text-xl font-bold text-foreground">{displayStats.topCities.length}</div>
-              <div className="text-2xs text-muted uppercase tracking-wide mt-0.5">cities</div>
-            </div>
+            {!hideLocationAggregates && (
+              <>
+                <div className="bg-background rounded-lg px-2 py-2 text-center">
+                  <div className="text-xl font-bold text-foreground">{displayStats.countryCount}</div>
+                  <div className="text-2xs text-muted uppercase tracking-wide mt-0.5">countries</div>
+                </div>
+                <div className="bg-background rounded-lg px-2 py-2 text-center">
+                  <div className="text-xl font-bold text-foreground">{displayStats.topCities.length}</div>
+                  <div className="text-2xs text-muted uppercase tracking-wide mt-0.5">cities</div>
+                </div>
+              </>
+            )}
             <div className="bg-background rounded-lg px-2 py-2 text-center">
               <div className="text-xl font-bold text-accent-orange">
                 {displayStats.avgFollowers >= 1000 ? `${(displayStats.avgFollowers / 1000).toFixed(1)}k` : displayStats.avgFollowers}
@@ -191,7 +207,7 @@ export const StatsModal = ({ open, onClose, owner, repo, displayStats, starsThis
         <div className="flex-1 flex flex-col min-h-0 min-w-0">
           {/* Tabs */}
           <div role="tablist" aria-label="Stats view" className="flex border-b border-border-subtle flex-shrink-0">
-            {(["top", "countries", "cities", "companies", "power", "rising"] as const).map((tab, idx, arr) => (
+            {(hideLocationAggregates ? TABS_WITHOUT_LOCATION : ALL_TABS).map((tab, idx, arr) => (
               <button
                 key={tab}
                 role="tab"

--- a/src/hooks/use-repo-cache-loader.test.ts
+++ b/src/hooks/use-repo-cache-loader.test.ts
@@ -219,6 +219,37 @@ describe("useRepoCacheLoader", () => {
     expect(opts.setTotal).toHaveBeenCalledWith(1);
   });
 
+  // 206 = "repo was scanned before, we just don't hold the blob" — the profile most likely
+  // to still have star_event rows, so the fallback chain must run here too, not only on 404.
+  it("runs the fallback chain on a 206 with no local cache", async () => {
+    mockLoadCache.mockReturnValue(null);
+    const reconstructPoints = [{ ...LOCAL_CACHE.points[0], login: "reconstructed-from-206" }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return jsonResponse({ lastScan: "2026-01-01" }, 206);
+      if (url.includes("/api/reconstruct/")) {
+        return jsonResponse({ points: reconstructPoints, unmapped: [], totalCount: 1 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const opts = makeOpts();
+    const { result } = renderHook(() => useRepoCacheLoader(opts));
+    await waitFor(() => expect(result.current.dataSource).toBe("reconstructed"));
+    expect(opts.dispatch).toHaveBeenCalledWith({ type: "set", points: reconstructPoints, unmapped: [] });
+    // A reconstructed map replaces the pre-scan dialog, so lastDbScan must stay unset.
+    expect(result.current.lastDbScan).toBeNull();
+  });
+
+  it("still sets lastDbScan on a 206 when every degraded source 404s", async () => {
+    mockLoadCache.mockReturnValue(null);
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return jsonResponse({ lastScan: "2026-02-02" }, 206);
+      return new Response(null, { status: 404 });
+    });
+    const { result } = renderHook(() => useRepoCacheLoader(makeOpts()));
+    await waitFor(() => expect(result.current.lastDbScan).toBe("2026-02-02"));
+    expect(result.current.dataSource).toBeNull();
+  });
+
   it("dataSource stays null when every source 404s", async () => {
     mockLoadCache.mockReturnValue(null);
     mockFetch.mockResolvedValue(new Response(null, { status: 404 }));

--- a/src/hooks/use-repo-cache-loader.test.ts
+++ b/src/hooks/use-repo-cache-loader.test.ts
@@ -181,4 +181,74 @@ describe("useRepoCacheLoader", () => {
     const { result } = renderHook(() => useRepoCacheLoader(makeOpts()));
     await waitFor(() => expect(result.current.cacheCheckDone).toBe(true));
   });
+
+  // ── fallback chain: reconstruct / engaged ─────────────────────────────────
+
+  it("falls back to /api/reconstruct when stargazer_cache 404s and no local cache", async () => {
+    mockLoadCache.mockReturnValue(null);
+    const reconstructPoints = [{ ...LOCAL_CACHE.points[0], login: "reconstructed-user" }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return new Response(null, { status: 404 });
+      if (url.includes("/api/reconstruct/")) {
+        return jsonResponse({ points: reconstructPoints, unmapped: [], totalCount: 1 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const opts = makeOpts();
+    const { result } = renderHook(() => useRepoCacheLoader(opts));
+    await waitFor(() => expect(result.current.dataSource).toBe("reconstructed"));
+    expect(opts.dispatch).toHaveBeenCalledWith({ type: "set", points: reconstructPoints, unmapped: [] });
+    expect(opts.setTotal).toHaveBeenCalledWith(1);
+  });
+
+  it("falls back to /api/engaged when both stargazer_cache and /api/reconstruct 404", async () => {
+    mockLoadCache.mockReturnValue(null);
+    const engagedPoints = [{ ...LOCAL_CACHE.points[0], login: "engaged-user" }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return new Response(null, { status: 404 });
+      if (url.includes("/api/reconstruct/")) return new Response(null, { status: 404 });
+      if (url.includes("/api/engaged/")) {
+        return jsonResponse({ points: engagedPoints, unmapped: [], knownCount: 1, starCount: 500, channels: ["fork"] });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const opts = makeOpts();
+    const { result } = renderHook(() => useRepoCacheLoader(opts));
+    await waitFor(() => expect(result.current.dataSource).toBe("engaged"));
+    expect(opts.dispatch).toHaveBeenCalledWith({ type: "set", points: engagedPoints, unmapped: [] });
+    expect(opts.setTotal).toHaveBeenCalledWith(1);
+  });
+
+  it("dataSource stays null when every source 404s", async () => {
+    mockLoadCache.mockReturnValue(null);
+    mockFetch.mockResolvedValue(new Response(null, { status: 404 }));
+    const { result } = renderHook(() => useRepoCacheLoader(makeOpts()));
+    await waitFor(() => expect(result.current.cacheCheckDone).toBe(true));
+    expect(result.current.dataSource).toBeNull();
+  });
+
+  it("does not attempt reconstruct/engaged fallback when local cache exists (donates instead)", async () => {
+    mockLoadCache.mockReturnValue(LOCAL_CACHE);
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return new Response(null, { status: 404 });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    const { result } = renderHook(() => useRepoCacheLoader(makeOpts()));
+    await waitFor(() => expect(mockCompressToBase64).toHaveBeenCalled());
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/reconstruct/"), expect.anything());
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining("/api/engaged/"), expect.anything());
+    expect(result.current.dataSource).toBe("cache");
+  });
+
+  it("dataSource is 'cache' when stargazer_cache 200s with fresh data", async () => {
+    mockLoadCache.mockReturnValue(null);
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) {
+        return jsonResponse({ points: LOCAL_CACHE.points, unmapped: [], totalCount: 1, scannedAt: new Date(2000).toISOString(), latestStarredAt: null });
+      }
+      return new Response(null, { status: 404 });
+    });
+    const { result } = renderHook(() => useRepoCacheLoader(makeOpts()));
+    await waitFor(() => expect(result.current.dataSource).toBe("cache"));
+  });
 });

--- a/src/hooks/use-repo-cache-loader.test.ts
+++ b/src/hooks/use-repo-cache-loader.test.ts
@@ -240,6 +240,23 @@ describe("useRepoCacheLoader", () => {
     expect(result.current.dataSource).toBe("cache");
   });
 
+  it("falls through to /api/engaged when /api/reconstruct fetch itself rejects (not just non-ok)", async () => {
+    mockLoadCache.mockReturnValue(null);
+    const engagedPoints = [{ ...LOCAL_CACHE.points[0], login: "engaged-after-reject" }];
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/stargazer-cache/")) return Promise.resolve(new Response(null, { status: 404 }));
+      if (url.includes("/api/reconstruct/")) return Promise.reject(new Error("network down"));
+      if (url.includes("/api/engaged/")) {
+        return jsonResponse({ points: engagedPoints, unmapped: [], knownCount: 1, starCount: 500, channels: ["fork"] });
+      }
+      return Promise.resolve(new Response(null, { status: 404 }));
+    });
+    const opts = makeOpts();
+    const { result } = renderHook(() => useRepoCacheLoader(opts));
+    await waitFor(() => expect(result.current.dataSource).toBe("engaged"));
+    expect(opts.dispatch).toHaveBeenCalledWith({ type: "set", points: engagedPoints, unmapped: [] });
+  });
+
   it("dataSource is 'cache' when stargazer_cache 200s with fresh data", async () => {
     mockLoadCache.mockReturnValue(null);
     mockFetch.mockImplementation((url: string) => {

--- a/src/hooks/use-repo-cache-loader.ts
+++ b/src/hooks/use-repo-cache-loader.ts
@@ -125,8 +125,13 @@ export const useRepoCacheLoader = ({
             donateLocalCacheToDb(owner, repo, validLocal);
             return;
           }
-          const reconstructRes = await fetch(`/api/reconstruct/${owner}/${repo}`, { signal: ac.signal });
-          if (reconstructRes.ok) {
+          // Each fallback fetch is caught independently — a thrown exception (offline, DNS
+          // failure) on one source must not abort the chain before the next source is tried.
+          let reconstructRes: Response | null = null;
+          try {
+            reconstructRes = await fetch(`/api/reconstruct/${owner}/${repo}`, { signal: ac.signal });
+          } catch { /* try the next source */ }
+          if (reconstructRes?.ok) {
             const rd = await reconstructRes.json();
             dispatch({ type: "set", points: rd.points, unmapped: rd.unmapped });
             setTotal(rd.totalCount);
@@ -134,8 +139,11 @@ export const useRepoCacheLoader = ({
             setDataSource("reconstructed");
             return;
           }
-          const engagedRes = await fetch(`/api/engaged/${owner}/${repo}`, { signal: ac.signal });
-          if (engagedRes.ok) {
+          let engagedRes: Response | null = null;
+          try {
+            engagedRes = await fetch(`/api/engaged/${owner}/${repo}`, { signal: ac.signal });
+          } catch { /* give up silently, same as the outer catch */ }
+          if (engagedRes?.ok) {
             const ed = await engagedRes.json();
             dispatch({ type: "set", points: ed.points, unmapped: ed.unmapped });
             setTotal(ed.knownCount);

--- a/src/hooks/use-repo-cache-loader.ts
+++ b/src/hooks/use-repo-cache-loader.ts
@@ -107,6 +107,44 @@ export const useRepoCacheLoader = ({
     }
 
     const ac = new AbortController();
+
+    // Degraded sources, tried in order of fidelity. Each fetch is caught independently — a
+    // thrown exception (offline, DNS failure) on one source must not abort the chain before
+    // the next source is tried. Returns true once a source has rendered a map.
+    // Callers deliberately skip saveCache/saveBookmark/donate afterwards: degraded data must
+    // never overwrite localStorage or the public badge counts.
+    const tryDegradedSources = async (): Promise<boolean> => {
+      let reconstructRes: Response | null = null;
+      try {
+        reconstructRes = await fetch(`/api/reconstruct/${owner}/${repo}`, { signal: ac.signal });
+      } catch { /* try the next source */ }
+      if (reconstructRes?.ok) {
+        const rd = await reconstructRes.json();
+        if (rd.points) {
+          dispatch({ type: "set", points: rd.points, unmapped: rd.unmapped });
+          setTotal(rd.totalCount);
+          setStatus("cached");
+          setDataSource("reconstructed");
+          return true;
+        }
+      }
+      let engagedRes: Response | null = null;
+      try {
+        engagedRes = await fetch(`/api/engaged/${owner}/${repo}`, { signal: ac.signal });
+      } catch { /* give up silently, same as the outer catch */ }
+      if (engagedRes?.ok) {
+        const ed = await engagedRes.json();
+        if (ed.points) {
+          dispatch({ type: "set", points: ed.points, unmapped: ed.unmapped });
+          setTotal(ed.knownCount);
+          setStatus("cached");
+          setDataSource("engaged");
+          return true;
+        }
+      }
+      return false;
+    };
+
     (async () => {
       try {
         const r = await fetch(`/api/stargazer-cache/${owner}/${repo}`, { signal: ac.signal });
@@ -116,8 +154,14 @@ export const useRepoCacheLoader = ({
         }
         if (r.status === 206) {
           const d = await r.json();
-          if (!validLocal) setLastDbScan(d.lastScan);
-          else donateLocalCacheToDb(owner, repo, validLocal);
+          if (validLocal) {
+            donateLocalCacheToDb(owner, repo, validLocal);
+            return;
+          }
+          // 206 means "scanned before, blob gone" — the profile most likely to still have
+          // star_event rows, so try reconstruction before offering a fresh scan.
+          if (await tryDegradedSources()) return;
+          setLastDbScan(d.lastScan);
           return;
         }
         if (!r.ok) {
@@ -125,32 +169,7 @@ export const useRepoCacheLoader = ({
             donateLocalCacheToDb(owner, repo, validLocal);
             return;
           }
-          // Each fallback fetch is caught independently — a thrown exception (offline, DNS
-          // failure) on one source must not abort the chain before the next source is tried.
-          let reconstructRes: Response | null = null;
-          try {
-            reconstructRes = await fetch(`/api/reconstruct/${owner}/${repo}`, { signal: ac.signal });
-          } catch { /* try the next source */ }
-          if (reconstructRes?.ok) {
-            const rd = await reconstructRes.json();
-            dispatch({ type: "set", points: rd.points, unmapped: rd.unmapped });
-            setTotal(rd.totalCount);
-            setStatus("cached");
-            setDataSource("reconstructed");
-            return;
-          }
-          let engagedRes: Response | null = null;
-          try {
-            engagedRes = await fetch(`/api/engaged/${owner}/${repo}`, { signal: ac.signal });
-          } catch { /* give up silently, same as the outer catch */ }
-          if (engagedRes?.ok) {
-            const ed = await engagedRes.json();
-            dispatch({ type: "set", points: ed.points, unmapped: ed.unmapped });
-            setTotal(ed.knownCount);
-            setStatus("cached");
-            setDataSource("engaged");
-            return;
-          }
+          await tryDegradedSources();
           return;
         }
         const data = await r.json();

--- a/src/hooks/use-repo-cache-loader.ts
+++ b/src/hooks/use-repo-cache-loader.ts
@@ -33,6 +33,7 @@ type Options = {
 type Result = {
   cacheCheckDone: boolean;
   lastDbScan: string | null;
+  dataSource: "cache" | "reconstructed" | "engaged" | null;
 };
 
 const donateLocalCacheToDb = (owner: string, repo: string, cache: LocalCache) => {
@@ -69,6 +70,7 @@ export const useRepoCacheLoader = ({
 }: Options): Result => {
   const [cacheCheckDone, setCacheCheckDone] = useState(false);
   const [lastDbScan, setLastDbScan] = useState<string | null>(null);
+  const [dataSource, setDataSource] = useState<"cache" | "reconstructed" | "engaged" | null>(null);
   // Local state is used when no external setter is provided (e.g. in tests).
   const [_serverStats, _setServerStats] = useState<RepoStats | null>(null);
   const setServerStats = externalSetServerStats ?? _setServerStats;
@@ -100,6 +102,7 @@ export const useRepoCacheLoader = ({
       setLatestStarredAt(validLocal.latestStarredAt ?? null);
       setStatus("cached");
       saveBookmark(owner, repo, validLocal.totalCount);
+      setDataSource("cache");
       setCacheCheckDone(true);
     }
 
@@ -118,7 +121,28 @@ export const useRepoCacheLoader = ({
           return;
         }
         if (!r.ok) {
-          if (validLocal) donateLocalCacheToDb(owner, repo, validLocal);
+          if (validLocal) {
+            donateLocalCacheToDb(owner, repo, validLocal);
+            return;
+          }
+          const reconstructRes = await fetch(`/api/reconstruct/${owner}/${repo}`, { signal: ac.signal });
+          if (reconstructRes.ok) {
+            const rd = await reconstructRes.json();
+            dispatch({ type: "set", points: rd.points, unmapped: rd.unmapped });
+            setTotal(rd.totalCount);
+            setStatus("cached");
+            setDataSource("reconstructed");
+            return;
+          }
+          const engagedRes = await fetch(`/api/engaged/${owner}/${repo}`, { signal: ac.signal });
+          if (engagedRes.ok) {
+            const ed = await engagedRes.json();
+            dispatch({ type: "set", points: ed.points, unmapped: ed.unmapped });
+            setTotal(ed.knownCount);
+            setStatus("cached");
+            setDataSource("engaged");
+            return;
+          }
           return;
         }
         const data = await r.json();
@@ -134,6 +158,7 @@ export const useRepoCacheLoader = ({
         setCachedAt(scannedMs);
         setLatestStarredAt(data.latestStarredAt ?? null);
         setStatus("cached");
+        setDataSource("cache");
         saveBookmark(owner, repo, data.totalCount);
         saveCache(owner, repo, {
           points: data.points,
@@ -195,5 +220,5 @@ export const useRepoCacheLoader = ({
     })();
   }, [owner, repo, setServerStats]);
 
-  return { cacheCheckDone, lastDbScan };
+  return { cacheCheckDone, lastDbScan, dataSource };
 };

--- a/src/lib/__tests__/coverage.test.ts
+++ b/src/lib/__tests__/coverage.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+import { describe, it, expect } from "vitest";
+import { computeCoverage } from "@/lib/coverage";
+
+describe("computeCoverage", () => {
+  it("applies the 0.3 geolocation-rate factor, not raw N/M", () => {
+    // N=1000, M=1000 → raw would be 100%, weighted should be 30%
+    expect(computeCoverage(1000, 1000)).toBe(30);
+  });
+
+  it("clamps at 100 when the weighted ratio would exceed it", () => {
+    expect(computeCoverage(10000, 1000)).toBe(100);
+  });
+
+  it("returns 0 when liveStarCount is 0", () => {
+    expect(computeCoverage(500, 0)).toBe(0);
+  });
+
+  it("rounds to the nearest integer", () => {
+    expect(computeCoverage(333, 1000)).toBe(10); // 0.3 * 333/1000 = 9.99 → 10
+  });
+});

--- a/src/lib/coverage.ts
+++ b/src/lib/coverage.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Florian Bruniaux <florian@bruniaux.com>
+
+// Weighted coverage: raw distinct-login-count / live-star-count overstates what
+// actually renders as a dot by roughly 3x, since only ~30% of github_user rows
+// carry a geolocation. See docs/ROADMAP.md Phase 2 for the measurement.
+const GEOLOCATION_RATE = 0.3;
+
+export const computeCoverage = (knownCount: number, liveStarCount: number): number => {
+  if (liveStarCount <= 0) return 0;
+  const raw = GEOLOCATION_RATE * (knownCount / liveStarCount) * 100;
+  return Math.min(100, Math.round(raw));
+};

--- a/src/lib/proxy.test.ts
+++ b/src/lib/proxy.test.ts
@@ -54,6 +54,22 @@ describe("proxy.ts", () => {
         "/api/stats/*/*/top-users",
       );
       expect(__TEST_ONLY__.routeKey("/api/watch/facebook/react")).toBe("/api/watch/*/*");
+      expect(__TEST_ONLY__.routeKey("/api/reconstruct/facebook/react")).toBe(
+        "/api/reconstruct/*/*",
+      );
+      expect(__TEST_ONLY__.routeKey("/api/engaged/facebook/react")).toBe("/api/engaged/*/*");
+    });
+
+    // Without "engaged"/"reconstruct" in STATIC_ROUTE_SEGMENTS both collapse to /api/*/*/*
+    // and share one bucket with every other 3-segment dynamic route.
+    it("keeps reconstruct and engaged on distinct rate-limit keys", async () => {
+      const { __TEST_ONLY__ } = await import("@/proxy");
+      expect(__TEST_ONLY__.routeKey("/api/reconstruct/a/b")).not.toBe(
+        __TEST_ONLY__.routeKey("/api/engaged/a/b"),
+      );
+      expect(__TEST_ONLY__.routeKey("/api/reconstruct/a/b")).not.toBe(
+        __TEST_ONLY__.routeKey("/api/stargazer-cache/a/b"),
+      );
     });
 
     it("leaves fully-static paths unchanged", async () => {
@@ -97,6 +113,22 @@ describe("proxy.ts", () => {
       const { __TEST_ONLY__ } = await import("@/proxy");
       expect(__TEST_ONLY__.classifyRoute("POST", "/api/chunk")).toBe("post");
       expect(__TEST_ONLY__.classifyRoute("DELETE", "/api/news/item/1")).toBe("post");
+    });
+
+    // Both serve the same bulk per-user PII as /api/stargazer-cache (login, name, company,
+    // location, followers, coordinates). Falling through to moderate-get would give them
+    // 60 req/min with no Referer or sm-token check, 20x the sibling route's budget.
+    it("classifies stargazer-cache, reconstruct and engaged on the same tight GET tier", async () => {
+      const { __TEST_ONLY__ } = await import("@/proxy");
+      expect(__TEST_ONLY__.classifyRoute("GET", "/api/stargazer-cache/facebook/react")).toBe(
+        "stargazer-cache-get",
+      );
+      expect(__TEST_ONLY__.classifyRoute("GET", "/api/reconstruct/facebook/react")).toBe(
+        "stargazer-cache-get",
+      );
+      expect(__TEST_ONLY__.classifyRoute("GET", "/api/engaged/facebook/react")).toBe(
+        "stargazer-cache-get",
+      );
     });
 
     it("classifies GET /api/roadmap-vote as moderate-get and POST as post", async () => {

--- a/src/lib/roadmap-vote-copy.ts
+++ b/src/lib/roadmap-vote-copy.ts
@@ -21,7 +21,7 @@ export const ROADMAP_OPTIONS: readonly RoadmapOptionCopy[] = [
     statusLabel: "Already shipping",
     label: "Map the engaged community, not just stargazers",
     sentence:
-      "A pipeline already crawls forks, issues, PRs and mentions instead of the closed stargazers list. Early runs recovered 6-16% of a repo's stargazer count, with 57-89% of those accounts carrying a usable location.",
+      "A pipeline already crawls forks, issues, PRs and mentions instead of the closed stargazers list. Early runs recovered 6-16% of a repo's stargazer count, with 57-89% of those accounts carrying a usable location. Now visible directly on any affected repo's map page, labeled honestly as engaged-community data, not a stargazer count.",
   },
   {
     option: "C",

--- a/src/lib/roadmap-vote-copy.ts
+++ b/src/lib/roadmap-vote-copy.ts
@@ -21,7 +21,7 @@ export const ROADMAP_OPTIONS: readonly RoadmapOptionCopy[] = [
     statusLabel: "Already shipping",
     label: "Map the engaged community, not just stargazers",
     sentence:
-      "A pipeline already crawls forks, issues, PRs and mentions instead of the closed stargazers list. Early runs recovered 6-16% of a repo's stargazer count, with 57-89% of those accounts carrying a usable location. Now visible directly on any affected repo's map page, labeled honestly as engaged-community data, not a stargazer count.",
+      "A pipeline already crawls forks, issues, PRs and mentions instead of the closed stargazers list. Early runs recovered 6-16% of a repo's stargazer count, with 57-89% of those accounts carrying a usable location. Now visible on repos indexed without a prior stargazer scan, labeled honestly as engaged-community data, not a stargazer count.",
   },
   {
     option: "C",

--- a/src/lib/stargazer-notice.ts
+++ b/src/lib/stargazer-notice.ts
@@ -28,6 +28,13 @@ export const STARGAZER_NOTICE_BODY: readonly string[] = [
   "I'm actively analysing what StarMapper can do next, including rebuilding the map from the user side rather than the repo side. Follow the links below for the official sources.",
 ];
 
+/** Paragraphs shown when a repo falls back to reconstructed or engaged data instead of a full scan. */
+export const STARGAZER_NOTICE_DEGRADED_BODY: readonly string[] = [
+  "On June 30 2026 GitHub announced restrictions on public API endpoints and UI views. Since July 23 the restriction reached the stargazers list.",
+  "This repo's map is not from a fresh stargazers scan. It's reconstructed from data StarMapper already holds, or built from the engaged community (forkers, contributors, issue and PR authors) instead. Both recover a slice of the real audience, not the full list.",
+  "Follow the links below for the official sources, or see the open options at /roadmap.",
+];
+
 export const STARGAZER_NOTICE_LINKS: readonly NoticeLink[] = [
   {
     label: "GitHub changelog (June 30 2026)",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -104,6 +104,8 @@ const TIER_LIMITERS: Record<
   Ratelimit
 > = {
   "strict-get":          makeLimiter("rl:strict-get", 30, "60 s"),
+  // Shared by every bulk per-user dump (stargazer-cache, reconstruct, engaged). The key is
+  // `${ip}:${routeKey}`, so each route still gets its own 3/60s bucket, not a shared one.
   "stargazer-cache-get": makeLimiter("rl:stargazer-cache-get", 3, "60 s"),
   "moderate-get":        makeLimiter("rl:moderate-get", 60, "60 s"),
   "admin":               makeLimiter("rl:admin", 10, "60 s"),
@@ -123,11 +125,11 @@ const STATIC_ROUTE_SEGMENTS = new Set([
   "api", "admin", "atlas", "autocomplete", "badge", "badge-update", "cache-status", "chunk",
   "cleanup", "clear-geocache", "companies", "contributors", "contributors-badge-update",
   "contributors-chunk", "country-stats", "daily-digest", "delete-user", "dependencies",
-  "dependents", "devs", "explore", "feed", "follower-cache", "followers-chunk", "geo",
+  "dependents", "devs", "engaged", "explore", "feed", "follower-cache", "followers-chunk", "geo",
   "geo-velocity", "geocode", "global-map", "growth", "import-geocache", "in", "influential",
   "item", "json", "locations", "map", "map-image", "mcp", "nearby", "news", "organic-score",
-  "organic-score-stats", "points", "power", "profile", "recalculate-location", "refresh",
-  "refresh-grid-mv", "refresh-repo-stats", "refresh-trending", "repo-info", "repos",
+  "organic-score-stats", "points", "power", "profile", "recalculate-location", "reconstruct",
+  "refresh", "refresh-grid-mv", "refresh-repo-stats", "refresh-trending", "repo-info", "repos",
   "roadmap-vote", "rss", "stargazer-cache", "stats", "top", "top-users", "track", "trending",
   "user-details", "user-repos", "users", "vitals", "watch",
 ]);
@@ -233,8 +235,16 @@ const classifyRoute = (method: string, pathname: string): Tier => {
   // (origin check + HMAC + default rate limit) rather than bypassing middleware silently.
   if (method !== "GET" && method !== "HEAD") return "post";
 
-  // Stargazer-cache GET — returns up to 50k users in one shot, dedicated tight limiter
-  if (pathname.startsWith("/api/stargazer-cache/")) return "stargazer-cache-get";
+  // Bulk per-user dumps — one request returns login/name/company/location/followers/coords
+  // for every user of a repo. /api/reconstruct and /api/engaged serve the same class of data
+  // as /api/stargazer-cache and must not sit on a looser tier than it.
+  if (
+    pathname.startsWith("/api/stargazer-cache/") ||
+    pathname.startsWith("/api/reconstruct/") ||
+    pathname.startsWith("/api/engaged/")
+  ) {
+    return "stargazer-cache-get";
+  }
 
   // Strict GET — data-rich endpoints with per-user PII (logins, locations, coordinates)
   // Note: /api/repos is intentionally excluded — it only returns aggregate badge stats,


### PR DESCRIPTION
## Summary

Closes the read-side gap found while auditing `docs/ROADMAP.md`: the engaged-audience write pipeline (`570a367`, shipped 2026-07-26) had no consumer, and Phase 1 (reconstruction from `star_event`) was never built. Both are now live behind a fallback chain, plus the coverage-metric groundwork and a roadmap-copy correction.

- `GET /api/engaged/[owner]/[repo]` and `GET /api/reconstruct/[owner]/[repo]`, mirroring the existing `stargazer-cache` route pattern
- `use-repo-cache-loader.ts` fallback chain: `stargazer_cache` → `/api/reconstruct` → `/api/engaged` → give up, including the `206` (scanned-before, no blob) branch
- `DataSourceBadge` labels degraded data honestly instead of presenting it as a full scan
- `computeCoverage()` weighted formula + `BadgeCache` schema columns for Phase 2 (write path intentionally deferred)
- `/roadmap` option A copy corrected to match what's actually visible now (verified live against prod: 10 `engaged_cache` rows currently lack a `stargazer_cache` sibling)

A final whole-branch review (opus) found 2 Critical and 6 Important issues, all fixed in a single follow-up pass:
- unbounded `star_event ⨝ github_user` join with no cap/timeout handling → `LIMIT 10_000`, `maxDuration`, Neon-timeout catch, mirroring `mcp/influential`
- both new routes fell through to the loosest proxy tier despite serving the same bulk per-user PII as `stargazer-cache` → reclassified onto the same tight tier, proxy tests extended
- `206` branch skipped the fallback chain entirely (the most common case for a usable `star_event` repo)
- engaged-sourced maps would've shown misleading "0 countries/companies" (stats panel now hides those rows for `dataSource === "engaged"`)
- discarded `linkedinUrl`, badge/TopPanel viewport collision, undocumented routes

Full plan and task-by-task ledger: `docs/superpowers/plans/2026-07-31-github-restriction-recovery.md`.

## Test plan

- [x] `rtk tsc` — 0 errors
- [x] `rtk vitest run` — 488/488 suites, 1222/1222 tests
- [ ] Visual check of `DataSourceBadge` placement at narrow viewport (moved but not browser-verified, see PR discussion)
- [ ] Confirm `ShareModal`'s "0 COUNTRIES" tile for engaged-sourced maps (known residual, out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013z3RJWMwzuWLtNuNP9oVAL