### PR TITLE
chore(ops): version-control the Vercel WAF configuration

### DIFF
--- a/.claude/rules/known-gotchas.md
+++ b/.claude/rules/known-gotchas.md
@@ -136,6 +136,19 @@ Ce bug a cassé 122/123 caches du batch indexer (nosia : 2/208 mappés au lieu d
 
 `src/lib/user-cache.ts` appelle `checkDbHealth()` avant chaque write. Si le DB est > 95% capacité, les writes `GitHubUser`/`StarEvent` sont silencieusement ignorés. Intentionnel.
 
+## WAF : la règle de bypass camo doit rester en position 1
+
+Les cartes embarquées dans les README passent par le proxy image de GitHub (`github-camo`), qui frappe **uniquement** `/api/map-image/*`, environ 2 400 requêtes par jour. Camo n'exécute pas de JavaScript : un challenge le bloque aussi sûrement qu'un deny.
+
+Les règles WAF s'évaluent de haut en bas et la première qui deny ou challenge arrête la chaîne. La règle `Bypass GitHub camo and badge embeds` doit donc rester au-dessus de toute règle terminale, en particulier si le managed ruleset Bot Protection passe un jour de `log` à `challenge`.
+
+```bash
+vercel firewall rules list           # vérifier l'ordre
+vercel firewall rules reorder "Bypass GitHub camo and badge embeds" --first --yes
+```
+
+Après toute modification publiée, relancer `pnpm ops:firewall-snapshot` pour que `docs/firewall-config.json` reflète la production. Le script refuse de tourner tant que des drafts sont en attente, ce qui évite d'enregistrer un état qui ne sert pas le trafic.
+
 ---
 
 **Auto-loaded**: ce fichier est chargé automatiquement à chaque session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ pnpm db:pull                     # Full dump + restore: prod → local
 
 make maintenance                 # Interactive wizard: checkboxes per step, dry-run prompt, then calls maintenance.sh
 pnpm stats:views                 # Analytics overview (last 7 days, top 20)
+pnpm ops:firewall-snapshot       # Record the live Vercel WAF config into docs/firewall-config.json
+pnpm ops:firewall-snapshot --check  # Exit 1 if that file no longer matches production
 
 # ─── Indexing new repos ───────────────────────────────────────────────────────
 make auto-index                  # Discover + scan 100 new trending repos → Neon prod (default)

--- a/PLAN-ACTION-V2.md
+++ b/PLAN-ACTION-V2.md
@@ -186,6 +186,37 @@ Sans persistent action, chaque requête d'un client déjà identifié est réév
 
 Les règles s'évaluent de haut en bas et la première qui deny ou challenge arrête la chaîne. L'ordre ci-dessous n'est pas indicatif, il est la sécurité du dispositif.
 
+### État au 18/08 : trois règles stagées, aucune publiée
+
+`vercel firewall rules add` fonctionne en script et **stage un draft** au lieu d'appliquer. Les règles 1, 2 et 3 sont donc déjà écrites et attendent ta publication :
+
+```
++ 1  Bypass GitHub camo and badge embeds        Bypass   (nouveau)
++ 2  Bypass MCP clients                         Bypass   (nouveau)
+  3  Block Alibaba SG ASN 45102                 Deny     (existant, 26 req/j)
++ 4  Scraper hosting ASNs (STAGING: log only)   Log      (nouveau)
+```
+
+Trois commandes, dans cet ordre :
+
+```bash
+vercel firewall diff             # relire ce qui va partir
+vercel firewall publish --yes    # appliquer
+vercel firewall discard --yes    # ou tout annuler
+```
+
+La règle 3 est volontairement en **`Log`** et non en `Deny`. La discipline de staging veut 24 h d'observation avant toute action terminale, parce qu'un ASN peut abriter des clients légitimes qu'aucune mesure agrégée ne révèle. Après vérification dans le dashboard :
+
+```bash
+vercel firewall rules edit "Scraper hosting ASNs (STAGING: log only)" \
+  --condition '{"type":"geo_as_number","op":"inc","value":["212238","18779","30058","62874","201341"]}' \
+  --action deny --duration 1h --yes
+```
+
+Attention, `edit --condition` **écrase toutes les conditions** de la règle, d'où la répétition de la condition complète ci-dessus.
+
+Les règles 5 et 6 restent à faire, elles sont décrites plus bas.
+
 **Règle 1, Bypass, à créer en premier.**
 Condition : `Request Path` starts with `/api/map-image` OR starts with `/api/badge`.
 Action : Bypass.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "seed:geonames": "tsx scripts/backfill/seed-geocache-geonames.ts",
     "seed:geonames:dry": "tsx scripts/backfill/seed-geocache-geonames.ts --dry-run",
     "stats:views": "tsx scripts/ops/view-stats.ts",
+    "ops:firewall-snapshot": "bash scripts/ops/snapshot-firewall.sh",
     "maintenance": "tsx scripts/ops/maintenance-wizard.ts",
     "db:seed:trending-watchlist": "echo 'Target required: pnpm db:seed:trending-watchlist:local OR :prod' && exit 1",
     "db:seed:trending-watchlist:local": "sh -c 'set -a && . .env.local && set +a && DATABASE_DRIVER=standard DATABASE_URL=$DATABASE_URL_LOCAL tsx scripts/db/seed-trending-watchlist.ts \"$@\"' _",

--- a/scripts/ops/snapshot-firewall.sh
+++ b/scripts/ops/snapshot-firewall.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Snapshot the live Vercel firewall configuration into the repo.
+#
+# WAF rules live in Vercel's dashboard, not in git: no diff, no blame, no revert if
+# someone loosens a rule. vercel.json cannot close the gap either, because its
+# routes[].mitigate form supports only deny and challenge, while the rules that keep
+# GitHub camo reachable are bypass.
+#
+# So this writes the live config to docs/firewall-config.json on demand. It is a
+# record, not a source of truth: re-running it after every publish is what makes the
+# file worth keeping.
+#
+# Usage:
+#   pnpm ops:firewall-snapshot           # write the snapshot
+#   pnpm ops:firewall-snapshot --check   # exit 1 if stale (for CI)
+
+set -euo pipefail
+
+OUT="docs/firewall-config.json"
+CHECK=0
+[[ "${1:-}" == "--check" ]] && CHECK=1
+
+command -v vercel >/dev/null || { echo "vercel CLI not found: pnpm add -g vercel" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq not found: brew install jq" >&2; exit 1; }
+[[ -d .vercel ]] || { echo "project not linked, run: vercel link" >&2; exit 1; }
+
+# Temp file sits next to the output rather than in $TMPDIR, so the final mv stays on
+# one filesystem and is therefore atomic: a killed run cannot leave a truncated file.
+mkdir -p "$(dirname "$OUT")"
+TMP="$OUT.tmp"
+trap 'rm -f "$TMP"' EXIT
+
+# One call carries everything: .active (live rules, IP blocks, managed rulesets, CRS),
+# .bypass (system bypass), .attackMode, .draft (staged but not published).
+RAW="$(vercel firewall overview --json 2>/dev/null)"
+[[ -n "$RAW" ]] || { echo "vercel firewall overview returned nothing, are you logged in?" >&2; exit 1; }
+
+# A snapshot taken with drafts pending would record a state that is not serving traffic.
+if [[ "$(jq -r '.draft // empty | if . == {} then "" else "yes" end' <<<"$RAW")" == "yes" ]]; then
+  echo "unpublished draft changes are pending, publish or discard them first" >&2
+  echo "  vercel firewall diff" >&2
+  exit 1
+fi
+
+# Dropped on purpose:
+#   ownerId / projectKey  this repo is public, team and project ids do not belong in it
+#   changes               an audit log carrying usernames and userIds, and pure churn
+#   id / updatedAt        the git commit already records when and what changed
+# jq -S sorts keys, so a reordering by the API does not surface as a diff.
+jq -S '{
+  firewallEnabled: .active.firewallEnabled,
+  managedRules:    .active.managedRules,
+  crs:             .active.crs,
+  rules:           .active.rules,
+  ipBlocks:        .active.ips,
+  systemBypass:    .bypass,
+  attackMode:      .attackMode,
+}' <<<"$RAW" > "$TMP"
+
+if [[ $CHECK -eq 1 ]]; then
+  if ! diff -q "$TMP" "$OUT" >/dev/null 2>&1; then
+    echo "$OUT is stale, run: pnpm ops:firewall-snapshot" >&2
+    diff "$OUT" "$TMP" || true
+    exit 1
+  fi
+  echo "$OUT matches the live configuration"
+  exit 0
+fi
+
+mv "$TMP" "$OUT"
+trap - EXIT
+echo "wrote $OUT: $(jq '.rules | length' "$OUT") custom rules, $(jq '.ipBlocks | length' "$OUT") IP blocks, bot protection $(jq -r '.managedRules.bot_protection.action // "off"' "$OUT")"


### PR DESCRIPTION
## Why

WAF rules live in Vercel's dashboard, not in git. If someone loosens a rule there is no diff, no blame, and nothing to revert to.

`vercel.json` cannot close the gap: its `routes[].mitigate` form supports only `deny` and `challenge`, while the rules that keep GitHub camo reachable are `bypass`.

## What

```bash
pnpm ops:firewall-snapshot           # write docs/firewall-config.json
pnpm ops:firewall-snapshot --check   # exit 1 if it drifted from production (CI-ready)
```

`vercel firewall overview --json` already carries `.active`, `.bypass`, `.attackMode` and `.draft`, so one call does the job.

**Deliberately stripped from the snapshot:**

| Field | Reason |
|---|---|
| `ownerId`, `projectKey` | this repo is public, team and project ids do not belong in it |
| `.changes` | an audit log carrying usernames and userIds, and pure churn |
| `id`, `updatedAt` | the git commit already records when things changed |

`jq -S` sorts keys so an API-side reordering does not read as a diff.

## Two safety properties

The script **refuses to run while drafts are pending**, because a snapshot taken then would record a state that is not serving traffic.

The temp file sits beside the output rather than in `$TMPDIR`, so the final `mv` stays on one filesystem and is therefore atomic: an interrupted run cannot leave a truncated file.

## Documented gotcha

`.claude/rules/known-gotchas.md` gains the rule-order constraint: `github-camo` hits only `/api/map-image/*` (~2 400 req/day) and executes no JavaScript, so a challenge blocks it exactly like a deny. Its bypass rule has to stay above any terminal rule.

## Note

`docs/firewall-config.json` is not in this PR: three staged rules are currently pending publication, and the guard correctly blocks snapshotting until they are published or discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)