### PR TITLE
chore(ops): record the published firewall configuration

### DIFF
--- a/docs/firewall-config.json
+++ b/docs/firewall-config.json
@@ -1,0 +1,182 @@
+{
+  "attackMode": {
+    "enabled": false
+  },
+  "crs": {
+    "gen": {
+      "action": "log",
+      "active": true
+    },
+    "java": {
+      "action": "log",
+      "active": false
+    },
+    "lfi": {
+      "action": "log",
+      "active": false
+    },
+    "ma": {
+      "action": "log",
+      "active": false
+    },
+    "php": {
+      "action": "log",
+      "active": false
+    },
+    "rce": {
+      "action": "log",
+      "active": true
+    },
+    "rfi": {
+      "action": "log",
+      "active": false
+    },
+    "sd": {
+      "action": "log",
+      "active": false
+    },
+    "sf": {
+      "action": "log",
+      "active": false
+    },
+    "sqli": {
+      "action": "log",
+      "active": true
+    },
+    "xss": {
+      "action": "log",
+      "active": true
+    }
+  },
+  "firewallEnabled": true,
+  "ipBlocks": [],
+  "managedRules": {
+    "bot_protection": {
+      "action": "log",
+      "active": true,
+      "updatedAt": "2026-08-16T17:37:34.207Z"
+    }
+  },
+  "rules": [
+    {
+      "action": {
+        "mitigate": {
+          "action": "bypass",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "pre",
+              "type": "path",
+              "value": "/api/map-image"
+            }
+          ]
+        },
+        {
+          "conditions": [
+            {
+              "op": "pre",
+              "type": "path",
+              "value": "/api/badge"
+            }
+          ]
+        }
+      ],
+      "id": "rule_bypass_git_hub_camo_and_badge_embeds_0JDSgk",
+      "name": "Bypass GitHub camo and badge embeds",
+      "valid": true,
+      "validationErrors": null
+    },
+    {
+      "action": {
+        "mitigate": {
+          "action": "bypass",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "pre",
+              "type": "path",
+              "value": "/api/mcp"
+            }
+          ]
+        }
+      ],
+      "id": "rule_bypass_mcp_clients_nwPV1J",
+      "name": "Bypass MCP clients",
+      "valid": true,
+      "validationErrors": null
+    },
+    {
+      "action": {
+        "mitigate": {
+          "action": "deny",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "eq",
+              "type": "geo_as_number",
+              "value": "45102"
+            }
+          ]
+        }
+      ],
+      "id": "rule_log_alibaba_sg_asn_45102_scraping_investigation_3UjETp",
+      "name": "Block Alibaba SG ASN 45102 (confirmed scraping, 71k/h)",
+      "valid": true,
+      "validationErrors": null
+    },
+    {
+      "action": {
+        "mitigate": {
+          "action": "log",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "inc",
+              "type": "geo_as_number",
+              "value": [
+                "212238",
+                "18779",
+                "30058",
+                "62874",
+                "201341"
+              ]
+            }
+          ]
+        }
+      ],
+      "id": "rule_scraper_hosting_as_ns_staging_log_only_KZ3KCZ",
+      "name": "Scraper hosting ASNs (STAGING: log only)",
+      "valid": true,
+      "validationErrors": null
+    }
+  ],
+  "systemBypass": []
+}


### PR DESCRIPTION
First snapshot, taken after publishing the two bypass rules and the ASN log rule.

## Live configuration

| # | Rule | Action |
|---|---|---|
| 1 | Bypass GitHub camo and badge embeds | `bypass` |
| 2 | Bypass MCP clients | `bypass` |
| 3 | Block Alibaba SG ASN 45102 | `deny` |
| 4 | Scraper hosting ASNs (STAGING: log only) | `log` |

Order is the safety property, and it is preserved here: both bypasses sit above the Alibaba deny, so a request to `/api/map-image` never reaches a terminal rule.

Verified in production after publishing:

```
$ curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
    -A "github-camo (ed775dbb)" \
    https://starmapper.bruniaux.com/api/map-image/rtk-ai/rtk
200 image/svg+xml
```

## Notes

`bot_protection` is recorded as `log`, which is its current state and not a recommendation. Flipping it to `challenge` is the next step and will surface as a diff on this file.

Rule 4 is deliberately `log` rather than `deny`. Seven days of measurement point at those five ASNs, but an aggregate never shows the single legitimate client hiding inside one. It gets 24h of observation first.

Checked before committing: no `ownerId`, `projectKey`, `userId` or `username` survives the jq filter. `pnpm ops:firewall-snapshot --check` reports the file matches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)