### PR TITLE
chore(config): drop crons refreshing stargazer data to 1x/day

### DIFF
--- a/.claude/rules/known-gotchas.md
+++ b/.claude/rules/known-gotchas.md
@@ -67,7 +67,9 @@ Sans le gate : `error: The server does not support SSL connections` au premier `
 
 ## Cron trending : migrer la DB avant que le code parte en prod
 
-Le cron `30 */6 * * *` (`/api/admin/refresh-trending`) appelle `selectRefreshTargets` qui lit `trending_watchlist` + `trending_refresh`. Si le code est déployé avant le `prisma db push` sur Neon, le cron throw toutes les 6h (tables inexistantes). Inoffensif si `CRON_SECRET` non défini (route → 404). Pas de corruption : `/trending` continue sur le MV existant. Migration prod = push schema + recréer le MV 30j (`scripts/db/sql/create-trending-mv.sql`) + seed watchlist.
+Le cron `15 1 * * *` (`/api/admin/refresh-trending`) appelle `selectRefreshTargets` qui lit `trending_watchlist` + `trending_refresh`. Si le code est déployé avant le `prisma db push` sur Neon, le cron throw une fois par jour (tables inexistantes). Inoffensif si `CRON_SECRET` non défini (route → 404). Pas de corruption : `/trending` continue sur le MV existant. Migration prod = push schema + recréer le MV 30j (`scripts/db/sql/create-trending-mv.sql`) + seed watchlist.
+
+**Crons ramenés à 1x/jour le 2026-08-20** : `star_event` et `badge_cache` sont gelés depuis que GitHub a coupé la connexion `stargazers` (23/07, voir `docs/ROADMAP.md` Phase 3, bloquée sans échéance). `refresh-grid-mv`, `refresh-trending` et les deux parts de `refresh-repo-stats` tournaient sur une source qui ne bouge plus, pour un coût réel en écritures ISR (`revalidateTag("trending")` réécrit une entrée de 14,7 Mo à chaque passage). Ordre horaire à respecter si retouché : `refresh-grid-mv` (01:00) doit toujours précéder `refresh-repo-stats?part=1` (02:00), sa marge de sécurité, `repo_power_users_mv` dépend de `power_users_mv` qu'il reconstruit.
 
 ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -6,11 +6,11 @@
     },
     {
       "path": "/api/admin/refresh-grid-mv",
-      "schedule": "0 */4 * * *"
+      "schedule": "0 1 * * *"
     },
     {
       "path": "/api/admin/refresh-trending",
-      "schedule": "30 */6 * * *"
+      "schedule": "15 1 * * *"
     },
     {
       "path": "/api/admin/daily-digest",
@@ -18,11 +18,11 @@
     },
     {
       "path": "/api/admin/refresh-repo-stats?part=1",
-      "schedule": "0 2,14 * * *"
+      "schedule": "0 2 * * *"
     },
     {
       "path": "/api/admin/refresh-repo-stats?part=2",
-      "schedule": "20 2,14 * * *"
+      "schedule": "20 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Why

`star_event` and `badge_cache` have been frozen since 2026-07-23, when GitHub killed the `stargazers` GraphQL connection. Verified in prod:

```
day        star_event rows
2026-07-20   3,204
2026-07-21     113
2026-07-22       3
2026-07-23       6
...
2026-08-19       2
```

No recovery in a month. `docs/ROADMAP.md` confirms this isn't transient: Phase 3 (the only path back to live enumeration) is blocked without a committed date, pending a legal read.

## What

| Cron | Before | After |
|---|---|---|
| `refresh-grid-mv` | `0 */4 * * *` (6x/day) | `0 1 * * *` (1x/day) |
| `refresh-trending` | `30 */6 * * *` (4x/day) | `15 1 * * *` (1x/day) |
| `refresh-repo-stats?part=1` | `0 2,14 * * *` (2x/day) | `0 2 * * *` (1x/day) |
| `refresh-repo-stats?part=2` | `20 2,14 * * *` (2x/day) | `20 2 * * *` (1x/day) |
| `daily-digest`, `cleanup` | unchanged | unchanged, unrelated to stargazer data |

## Why this matters beyond cron CPU

Each `refresh-trending` pass calls `revalidateTag("trending")`, rewriting a ~14.7MB cache entry regardless of whether the underlying data moved. This was the direct cause of `/trending` landing at -48% ISR writes instead of the -98% projected in #126: the window fix worked, but the crons kept forcing rewrites on top of it.

## Ordering preserved

`refresh-grid-mv` (01:00) still runs before `refresh-repo-stats?part=1` (02:00), a 59-minute margin against its 300s budget. `repo_power_users_mv` reads `power_users_mv`, which `refresh-grid-mv` rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)