### PR TITLE
chore(ops): record repo-info and admin-cron bypass rules

### DIFF
--- a/docs/firewall-config.json
+++ b/docs/firewall-config.json
@@ -122,6 +122,58 @@
     {
       "action": {
         "mitigate": {
+          "action": "bypass",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "eq",
+              "type": "path",
+              "value": "/api/repo-info"
+            }
+          ]
+        }
+      ],
+      "id": "rule_bypass_repo_info_self_call_UPB3CV",
+      "name": "Bypass repo-info self-call",
+      "valid": true,
+      "validationErrors": null
+    },
+    {
+      "action": {
+        "mitigate": {
+          "action": "bypass",
+          "actionDuration": null,
+          "rateLimit": null,
+          "redirect": null
+        }
+      },
+      "active": true,
+      "conditionGroup": [
+        {
+          "conditions": [
+            {
+              "op": "pre",
+              "type": "path",
+              "value": "/api/admin"
+            }
+          ]
+        }
+      ],
+      "id": "rule_bypass_admin_cron_routes_FqWAYo",
+      "name": "Bypass admin cron routes",
+      "valid": true,
+      "validationErrors": null
+    },
+    {
+      "action": {
+        "mitigate": {
           "action": "deny",
           "actionDuration": null,
           "rateLimit": null,
@@ -148,8 +200,8 @@
     {
       "action": {
         "mitigate": {
-          "action": "log",
-          "actionDuration": null,
+          "action": "deny",
+          "actionDuration": "1h",
           "rateLimit": null,
           "redirect": null
         }

--- a/docs/firewall-config.json
+++ b/docs/firewall-config.json
@@ -74,7 +74,7 @@
             {
               "op": "pre",
               "type": "path",
-              "value": "/api/map-image"
+              "value": "/api/map-image/"
             }
           ]
         },
@@ -83,7 +83,7 @@
             {
               "op": "pre",
               "type": "path",
-              "value": "/api/badge"
+              "value": "/api/badge/"
             }
           ]
         }
@@ -109,7 +109,7 @@
             {
               "op": "pre",
               "type": "path",
-              "value": "/api/mcp"
+              "value": "/api/mcp/"
             }
           ]
         }
@@ -161,7 +161,7 @@
             {
               "op": "pre",
               "type": "path",
-              "value": "/api/admin"
+              "value": "/api/admin/"
             }
           ]
         }


### PR DESCRIPTION
Snapshot after publishing two bypass rules found while auditing what Bot Protection's Challenge mode would break.

## /api/repo-info

Last remaining server-to-server self-call in the codebase (`page.tsx:36`). Left as HTTP deliberately per `plan-action-code.md` §5.6, the internal hop isn't the cost driver, the uncached GitHub contributors fetch it wraps is.

That call carries zero browser signal. Without this bypass, Bot Protection in Challenge mode would silently blank every repo page's name, description, avatar and stats: `fetchRepoInfo`'s `catch { return null }` swallows a challenge-page response instead of throwing on invalid JSON.

Checked the rest of `src/app/api/` for the same pattern: `roadmap-vote`, `explore`, `profile` and `stats` were already converted to direct calls in #125. Nothing else remains.

## /api/admin/*

Covers the two crons from #129. Vercel's cron-jobs docs don't state whether cron invocations bypass the WAF, and "the cron endpoint receives a normal HTTP request" reads the other way.

All ten admin routes already gate on `CRON_SECRET` or `ADMIN_SECRET` (+ optional `ADMIN_ALLOWED_IPS`) independently of the WAF, so this bypass removes no real protection while closing a genuine unknown before Bot Protection goes live.

## Live rule order

```
1  Bypass GitHub camo and badge embeds
2  Bypass MCP clients
3  Bypass repo-info self-call
4  Bypass admin cron routes
5  Block Alibaba SG ASN 45102
6  Scraper hosting ASNs (Deny, 1h)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)