### PR TITLE
chore(ops): record the ASN scraper rule as a permanent deny

### DIFF
--- a/docs/firewall-config.json
+++ b/docs/firewall-config.json
@@ -201,7 +201,7 @@
       "action": {
         "mitigate": {
           "action": "deny",
-          "actionDuration": "1h",
+          "actionDuration": null,
           "rateLimit": null,
           "redirect": null
         }


### PR DESCRIPTION
24h of Log → Deny(1h) observation confirmed no legitimate traffic on the five scraper-hosting ASNs. You dropped `actionDuration` yourself and published:

```
> Success! Firewall config published to production [396ms]
```

This just records that state in `docs/firewall-config.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)