### PR TITLE
chore(ops): record Bot Protection challenge mode in firewall snapshot

### DIFF
--- a/docs/firewall-config.json
+++ b/docs/firewall-config.json
@@ -52,9 +52,9 @@
   "ipBlocks": [],
   "managedRules": {
     "bot_protection": {
-      "action": "log",
+      "action": "challenge",
       "active": true,
-      "updatedAt": "2026-08-16T17:37:34.207Z"
+      "updatedAt": "2026-08-23T17:40:59.633Z"
     }
   },
   "rules": [


### PR DESCRIPTION
## Summary
- Bot Protection basculé de `log` à `challenge` dans le dashboard Vercel (2026-08-23T17:40:59Z), dernier levier de l'effort de durcissement trafic/coût
- `docs/firewall-config.json` resynchronisé avec l'état live de production

## Contexte
Tous les blind spots identifiés ont été fermés et vérifiés actifs avant ce changement : bypass du self-call `repo-info`, bypass des crons admin, et la collision de préfixe `/api/badge` vs `/api/badge-update`.

Seuil de rollback : repasser en `log` si challenge dépasse 500/j ET taux de résolution < 10%, mesuré via `vercel metrics vercel.firewall_action.count -f "waf_rule_id eq 'managed_bot_protection'"`.

## Test plan
- [x] `vercel firewall overview --json` confirme `bot_protection.action = "challenge"` en prod
- [x] `docs/firewall-config.json` diff limité aux 2 lignes attendues (action + updatedAt)
- [ ] Suivi metrics à J+1 et J+2 pour valider le seuil de rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfPnHMv3W4afwHCAnkBHnN